### PR TITLE
Update gumbo_node_iterator.h and gumbo_util.h to solve warning C4099 and warning C4267

### DIFF
--- a/include/daw/gumbo_pp/gumbo_node_iterator.h
+++ b/include/daw/gumbo_pp/gumbo_node_iterator.h
@@ -34,7 +34,7 @@ namespace daw::gumbo {
 	private:
 		class children_t {
 			pointer node;
-			friend class gumbo_node_iterator_t;
+			friend struct gumbo_node_iterator_t;
 
 			explicit children_t( ) = default;
 			explicit constexpr children_t( pointer n ) noexcept

--- a/include/daw/gumbo_pp/gumbo_util.h
+++ b/include/daw/gumbo_pp/gumbo_util.h
@@ -140,7 +140,7 @@ namespace daw::gumbo {
 			return 0U;
 		}
 		default:
-			return std::char_traits<char>::length( node.v.text.text );
+			return static_cast<unsigned>(std::char_traits<char>::length(node.v.text.text));
 		}
 	}
 


### PR DESCRIPTION
Solve warning C4099: 'daw::gumbo::gumbo_node_iterator_t': type name first seen using 'struct' now seen using 'class'